### PR TITLE
VLAN interfaces test failing due to incorrect "append" function

### DIFF
--- a/resources/netbox_initial.yaml
+++ b/resources/netbox_initial.yaml
@@ -146,15 +146,27 @@ devices:
     device_types_slug: nexus9000v
     site_slug: demo 
     interfaces: 
+      - name: Port-channel 3232
+        decription: Test Portchannel
+        enabled: true
+        type: Link Aggregation Group (LAG)
+        mode: Tagged
+        untagged_vlan: virtualization
+        tagged_vlans:
+          - production-web
+          - production-app 
+          - production-data
       - name: Mgmt0
         description: Managment Interface 
         mgmt_only: true
         enabled: true
+        type: 1000BASE-T (1GE) 
         ip_addresses: 
           - address: 10.10.20.58/24 
             vrf: internal 
             primary: true 
-      - name: Ethernet1/1
+      - name: Ethernet 1/1
+        type: 1000BASE-T (1GE)
         enabled: true
         description: Inband Mgmt
         # mode: Tagged All
@@ -165,44 +177,37 @@ devices:
         enabled: true
         description: Link to dc-dist2
         mode: Tagged All
+        type: 1000BASE-T (1GE)
         # untagged_vlan: 
         # tagged_vlans:
         #   - 
       - name: Ethernet1/3
         enabled: true
         description: Link to virt1
-        mode: Tagged
-        untagged_vlan: virtualization
-        tagged_vlans:
-          - production-web
-          - production-app 
-          - production-data
+        type: 1000BASE-T (1GE)
+        lag: Port-channel 3232
+        #
       - name: Ethernet1/4
+        type: 1000BASE-T (1GE)
         enabled: true
         description: Link to virt2
-        mode: Tagged
-        untagged_vlan: virtualization
-        tagged_vlans:
-          - production-web
-          - production-app 
-          - production-data
+        lag: Port-channel 3232
+        #
       - name: Ethernet1/5
+        type: 1000BASE-T (1GE)
         enabled: true
         description: Link to virt3
-        mode: Tagged
-        untagged_vlan: virtualization
-        tagged_vlans:
-          - production-web
-          - production-app 
-          - production-data
+        lag: Port-channel 3232
+        #
       - name: Ethernet1/6
+        type: 1000BASE-T (1GE)
         enabled: false
         description: Link to data1
-        mode: Access
-        untagged_vlan: production-data
+        lag: Port-channel 3232
         # tagged_vlans:
         #   - 
       - name: Ethernet1/7
+        type: 1000BASE-T (1GE)
         enabled: false
         description: Link to data2
         mode: Access
@@ -210,6 +215,7 @@ devices:
         # tagged_vlans:
         #   - 
       - name: Ethernet1/8
+        type: 1000BASE-T (1GE)
         enabled: false
         description: Link to backup1
         mode: Access
@@ -217,6 +223,7 @@ devices:
         # tagged_vlans:
         #   - 
       - name: Ethernet1/9
+        type: 1000BASE-T (1GE)
         enabled: false
         description: Link to backup2
         mode: Access
@@ -224,6 +231,7 @@ devices:
         # tagged_vlans:
         #   - 
       - name: Ethernet1/10
+        type: 1000BASE-T (1GE)
         enabled: false
         # description: false
         # mode: 
@@ -231,6 +239,7 @@ devices:
         # tagged_vlans:
         #   - 
       - name: Ethernet1/11
+        type: 1000BASE-T (1GE)
         enabled: false
         # description: false
         # mode: 
@@ -238,6 +247,7 @@ devices:
         # tagged_vlans:
         #   - 
       - name: Ethernet1/12
+        type: 1000BASE-T (1GE)
         enabled: false
         # description: false
         # mode: 
@@ -245,6 +255,7 @@ devices:
         # tagged_vlans:
         #   - 
       - name: Ethernet1/13
+        type: 1000BASE-T (1GE)
         enabled: false
         # description: false
         # mode: 
@@ -252,6 +263,7 @@ devices:
         # tagged_vlans:
         #   - 
       - name: Ethernet1/14
+        type: 1000BASE-T (1GE)
         enabled: false
         # description: false
         # mode: 
@@ -259,6 +271,7 @@ devices:
         # tagged_vlans:
         #   - 
       - name: Ethernet1/15
+        type: 1000BASE-T (1GE)
         enabled: false
         # description: false
         # mode: 
@@ -266,783 +279,7 @@ devices:
         # tagged_vlans:
         #   - 
       - name: Ethernet1/16
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/17
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/18
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/19
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/20
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/21
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/22
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/23
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/24
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/25
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/26
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/27
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/28
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/29
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/30
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/31
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/32
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/33
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/34
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/35
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/36
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/37
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/38
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/39
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/40
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/41
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/42
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/43
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/44
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/45
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/46
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/47
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/48
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/49
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/50
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/51
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/52
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/53
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/54
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/55
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/56
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/57
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/58
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/59
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/60
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/61
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/62
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/63
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/64
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/65
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/66
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/67
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/68
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/69
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/70
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/71
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/72
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/73
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/74
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/75
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/76
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/77
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/78
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/79
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/80
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/81
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/82
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/83
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/84
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/85
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/86
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/87
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/88
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/89
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/90
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/91
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/92
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/93
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/94
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/95
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/96
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/97
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/98
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/99
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/100
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/101
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/102
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/103
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/104
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/105
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/106
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/107
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/108
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/109
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/110
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/111
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/112
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/113
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/114
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/115
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/116
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/117
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/118
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/119
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/120
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/121
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/122
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/123
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/124
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/125
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/126
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/127
+        type: 1000BASE-T (1GE)
         enabled: false
         # description: false
         # mode: 
@@ -1056,7 +293,18 @@ devices:
     device_types_slug: nexus9000v
     site_slug: demo 
     interfaces: 
+      - name: Port-channel 3232
+        decription: Test Portchannel
+        enabled: true
+        type: Link Aggregation Group (LAG)
+        mode: Tagged
+        untagged_vlan: virtualization
+        tagged_vlans:
+          - production-web
+          - production-app 
+          - production-data
       - name: Mgmt0
+        type: 1000BASE-T (1GE)
         description: DO NOT TOUCH CONFIG ON THIS INTERFACE
         mgmt_only: true
         enabled: true
@@ -1065,40 +313,17 @@ devices:
             vrf: internal 
             primary: true 
       - name: Ethernet1/1
+        type: 1000BASE-T (1GE)
         enabled: true
         description: Link to dc-dist1
-        mode: Tagged
-        # untagged_vlan: 
-        tagged_vlans:
-          - mgmt 
-          - prod 
-          - dev 
-          - test 
-          - security 
-          - iot 
-          - app1
-          - app2
-          - app3
-          - app4
-          - app5
+        lag: Port-channel 3232
       - name: Ethernet1/2
+        type: 1000BASE-T (1GE)
         enabled: true
         description: Link to dc-dist2
-        mode: Tagged
-        # untagged_vlan: 
-        tagged_vlans:
-          - mgmt 
-          - prod 
-          - dev 
-          - test 
-          - security 
-          - iot 
-          - app1
-          - app2
-          - app3
-          - app4
-          - app5
+        lag: Port-channel 3232
       - name: Ethernet1/3
+        type: 1000BASE-T (1GE)
         enabled: true
         description: Link to virt1
         mode: Tagged
@@ -1108,6 +333,7 @@ devices:
           - production-app 
           - production-data
       - name: Ethernet1/4
+        type: 1000BASE-T (1GE)
         enabled: true
         description: Link to virt2
         mode: Tagged
@@ -1117,6 +343,7 @@ devices:
           - production-app 
           - production-data
       - name: Ethernet1/5
+        type: 1000BASE-T (1GE)
         enabled: true
         description: Link to virt3
         mode: Tagged
@@ -1126,6 +353,7 @@ devices:
           - production-app 
           - production-data
       - name: Ethernet1/6
+        type: 1000BASE-T (1GE)
         enabled: false
         description: Link to data1
         mode: Access
@@ -1133,6 +361,7 @@ devices:
         # tagged_vlans:
         #   - 
       - name: Ethernet1/7
+        type: 1000BASE-T (1GE)
         enabled: false
         description: Link to data2
         mode: Access
@@ -1140,6 +369,7 @@ devices:
         # tagged_vlans:
         #   - 
       - name: Ethernet1/8
+        type: 1000BASE-T (1GE)
         enabled: false
         description: Link to backup1
         mode: Access
@@ -1147,6 +377,7 @@ devices:
         # tagged_vlans:
         #   - 
       - name: Ethernet1/9
+        type: 1000BASE-T (1GE)
         enabled: false
         description: Link to backup2
         mode: Access
@@ -1154,6 +385,7 @@ devices:
         # tagged_vlans:
         #   - 
       - name: Ethernet1/10
+        type: 1000BASE-T (1GE)
         enabled: false
         # description: false
         # mode: 
@@ -1161,6 +393,7 @@ devices:
         # tagged_vlans:
         #   - 
       - name: Ethernet1/11
+        type: 1000BASE-T (1GE)
         enabled: false
         # description: false
         # mode: 
@@ -1168,6 +401,7 @@ devices:
         # tagged_vlans:
         #   - 
       - name: Ethernet1/12
+        type: 1000BASE-T (1GE)
         enabled: false
         # description: false
         # mode: 
@@ -1175,6 +409,7 @@ devices:
         # tagged_vlans:
         #   - 
       - name: Ethernet1/13
+        type: 1000BASE-T (1GE)
         enabled: false
         # description: false
         # mode: 
@@ -1182,6 +417,7 @@ devices:
         # tagged_vlans:
         #   - 
       - name: Ethernet1/14
+        type: 1000BASE-T (1GE)
         enabled: false
         # description: false
         # mode: 
@@ -1189,6 +425,7 @@ devices:
         # tagged_vlans:
         #   - 
       - name: Ethernet1/15
+        type: 1000BASE-T (1GE)
         enabled: false
         # description: false
         # mode: 
@@ -1196,786 +433,46 @@ devices:
         # tagged_vlans:
         #   - 
       - name: Ethernet1/16
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/17
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/18
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/19
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/20
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/21
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/22
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/23
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/24
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/25
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/26
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/27
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/28
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/29
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/30
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/31
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/32
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/33
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/34
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/35
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/36
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/37
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/38
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/39
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/40
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/41
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/42
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/43
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/44
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/45
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/46
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/47
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/48
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/49
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/50
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/51
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/52
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/53
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/54
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/55
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/56
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/57
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/58
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/59
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/60
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/61
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/62
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/63
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/64
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/65
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/66
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/67
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/68
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/69
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/70
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/71
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/72
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/73
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/74
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/75
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/76
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/77
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/78
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/79
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/80
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/81
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/82
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/83
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/84
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/85
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/86
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/87
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/88
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/89
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/90
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/91
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/92
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/93
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/94
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/95
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/96
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/97
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/98
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/99
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/100
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/101
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/102
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/103
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/104
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/105
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/106
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/107
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/108
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/109
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/110
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/111
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/112
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/113
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/114
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/115
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/116
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/117
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/118
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/119
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/120
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/121
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/122
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/123
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/124
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/125
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/126
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   - 
-      - name: Ethernet1/127
-        enabled: false
-        # description: false
-        # mode: 
-        # untagged_vlan: 
-        # tagged_vlans:
-        #   -         
+        type: 1000BASE-T (1GE)
+        enabled: false
+        # description: false
+        # mode: 
+        # untagged_vlan: 
+        # tagged_vlans:
+        #   - 
+
+  - name: sbx-n9kv-b0
+    device_role_slug: access-switch 
+    manufacturer_slug: cisco 
+    device_types_slug: nexus9000v
+    site_slug: demo 
+    interfaces: 
+      - name: Port-channel 3232
+        decription: Test Portchannel
+        enabled: true
+        type: Link Aggregation Group (LAG)
+        mode: Tagged
+        untagged_vlan: virtualization
+        tagged_vlans:
+          - production-web
+          - production-app 
+          - production-data
+      - name: Mgmt0
+        type: 1000BASE-T (1GE)
+        description: DO NOT TOUCH CONFIG ON THIS INTERFACE
+        mgmt_only: true
+        enabled: true
+        ip_addresses: 
+          - address: 10.10.20.101/24
+            vrf: internal 
+            primary: true 
+      - name: Ethernet1/1
+        type: 1000BASE-T (1GE)
+        enabled: true
+        description: Link to dc-dist1
+        lag: Port-channel 3232
+      - name: Ethernet1/2
+        type: 1000BASE-T (1GE)
+        enabled: true
+        description: Link to dc-dist2
+        lag: Port-channel 3232

--- a/resources/prepare_netbox.py
+++ b/resources/prepare_netbox.py
@@ -12,11 +12,18 @@ nb_token = os.getenv("NETBOX_TOKEN")
 
 nb = pynetbox.api(url=nb_url, token=nb_token)
 
-interface_modes = nb.dcim.choices()["interface:mode"]
+#interface_modes = nb.dcim.custom_choices()["interface:mode"]
 interface_mode = {
     "Access": 100, 
     "Tagged": 200, 
     "Tagged All": 300,
+}
+
+interface_type = {
+    "1000BASE-T (1GE)": 1000,
+    "10GBASE-T (10GE)": 1150,
+    "Virtual": 0,
+    "Link Aggregation Group (LAG)": 200,
 }
 
 # sites: 
@@ -137,7 +144,8 @@ for device in data["devices"]:
         if not nb_interface: 
             nb_interface = nb.dcim.interfaces.create(
                 device=nb_device.id, 
-                name=interface["name"], 
+                name=interface["name"],
+                type=interface_type[interface["type"]] 
             )
         if "description" in interface.keys():
             nb_interface.description = interface["description"]
@@ -156,6 +164,8 @@ for device in data["devices"]:
                 # print("VLAN LIST")
                 # print(vl)
                 nb_interface.tagged_vlans = vl
+        if "lag" in interface.keys():
+            nb_interface.lag = nb.dcim.interfaces.get(name=interface["lag"],device=device["name"]).id
         if "ip_addresses" in interface.keys(): 
             for ip in interface["ip_addresses"]: 
                 print(f"  Adding IP {ip['address']}")

--- a/resources/server_initial.yaml
+++ b/resources/server_initial.yaml
@@ -1,0 +1,68 @@
+# vars:
+#    device_name: we5.tehdc.relex.fi
+#    device_role: service server
+#    device_type: fc640
+#    site: eqhe7
+#    #status: Active
+
+devices:
+  - name: we6.tehdc.relex.fi
+    device_role_slug: service-server
+    #manufacturer_slug: cisco 
+    device_types_slug: fc640
+    site_slug: tehdc
+    # custom_fields:
+    #   - ansible_ssh_ip: we6.tehdc.prv.relex.fi
+    interfaces:
+    #   - name: idrac
+    #     enabled: true
+    #     type: 1000BASE-T (1GE)
+    #     mgmt_only: true
+    #     ip_addresses:
+    #       - address: 10.24.1.241/23 
+    #         description: we1.tehdc.mgmt.relex.fi
+        #  -
+      - name: team0
+        description: Aggregated interface
+        enabled: true
+        type: Link Aggregation Group (LAG)
+        #  -
+      - name: eno1
+        description: eno1
+        enabled: true
+        type: 1000BASE-T (1GE)
+        lag: team0
+        #  -
+      - name: eno2
+        description: eno2
+        enabled: true
+        type: 1000BASE-T (1GE)
+        lag: team0
+        #  -
+      - name: eno3
+        description: eno3
+        enabled: true
+        type: 1000BASE-T (1GE)
+        lag: team0
+        #  -
+      - name: eno4
+        description: eno4
+        enabled: true
+        type: 1000BASE-T (1GE)
+        lag: team0
+        #  -
+      - name: team0.102
+        description: DMZ_VLAN
+        type: Virtual
+        enabled: true
+        ip_addresses:
+          - address: 10.24.3.241/23 
+            description: we1.tehdc.dmz.relex.fi
+      - name: team0.104
+        description: PRV_VLAN
+        type: Virtual
+        enabled: true
+        ip_addresses:
+          - address: 10.24.5.241/23 
+            description: we1.tehdc.prv.relex.fi
+            

--- a/resources/server_netbox.py
+++ b/resources/server_netbox.py
@@ -1,0 +1,205 @@
+import pynetbox 
+import yaml 
+import os 
+
+data_file = "server_initial.yaml"
+
+with open(data_file) as f: 
+    data = yaml.safe_load(f.read())
+
+nb_url = os.getenv("NETBOX_URL")
+nb_token = os.getenv("NETBOX_TOKEN")
+
+nb = pynetbox.api(url=nb_url, token=nb_token)
+
+# List of Interfaces Types
+interface_type = {
+    "1000BASE-T (1GE)": 1000,
+    "10GBASE-T (10GE)": 1150,
+    "Virtual": 0,
+    "Link Aggregation Group (LAG)": 200,
+}
+
+# devices
+for device in data["devices"]: 
+    print(f"Creating or Updating device {device['name']}")
+    nb_device = nb.dcim.devices.get(name=device["name"])
+    if not nb_device: 
+        nb_device = nb.dcim.devices.create(
+            name=device["name"], 
+            #manufacturer=nb.dcim.manufacturers.get(slug=device["manufacturer_slug"]).id, 
+            site=nb.dcim.sites.get(slug=device["site_slug"]).id,
+            device_role=nb.dcim.device_roles.get(slug=device["device_role_slug"]).id, 
+            device_type=nb.dcim.device_types.get(slug=device["device_types_slug"]).id,
+            #ansible_ssh_ip=nb.dcim.devices.filter(name=device["name"],custom_fields=device["ansible_ssh_ip"]) 
+            )
+    else:
+        nb_device.update({
+        "name": device["name"], 
+        "site" : nb.dcim.sites.get(slug=device["site_slug"]).id,
+        "device_role": nb.dcim.device_roles.get(slug=device["device_role_slug"]).id, 
+        "device_type": nb.dcim.device_types.get(slug=device["device_types_slug"]).id, 
+        })
+    for interface in device["interfaces"]: 
+        print(f"  Creating or updating interface {interface['name']}")
+        nb_interface = nb.dcim.interfaces.get(
+            device_id=nb_device.id, 
+            name=interface["name"]
+        )
+        if not nb_interface: 
+            nb_interface = nb.dcim.interfaces.create(
+                device=nb_device.id, 
+                name=interface["name"],
+                type=interface_type[interface["type"]] 
+            )
+        else:
+            nb_interface.update({
+                "device": nb_device.id, 
+                "name": interface["name"],
+                "type": interface_type[interface["type"]] 
+            })
+        if "description" in interface.keys():
+            nb_interface.description = interface["description"]
+        if "mgmt_only" in interface.keys():
+            nb_interface.mgmt_only = interface["mgmt_only"]
+        if "enabled" in interface.keys():
+            nb_interface.enabled = interface["enabled"]
+        if "lag" in interface.keys():
+            nb_interface.lag = nb.dcim.interfaces.get(name=interface["lag"],device=device["name"]).id
+        if "ip_addresses" in interface.keys(): 
+            for ip in interface["ip_addresses"]: 
+                print(f"  Adding IP {ip['address']}")
+                nb_ipadd = nb.ipam.ip_addresses.get(
+                    address = ip["address"],
+                    description=  ip["description"],
+                )
+                if not nb_ipadd: 
+                    nb_ipadd = nb.ipam.ip_addresses.create(
+                        address = ip["address"],
+                        description=  ip["description"],
+                    )
+                # else:
+                #     nb_ipadd.update({
+                #         "address": ip["address"],
+                #         "description":  ip["description"],
+                #     })
+                nb_ipadd.interface = nb_interface.id
+                nb_ipadd.save()
+                if "primary" in ip.keys(): 
+                    nb_device.primary_ip4 = nb_ipadd.id
+                    nb_device.save()
+        
+        nb_interface.save()
+
+#interface_modes = nb.dcim.custom_choices()["interface:mode"]
+# interface_mode = {
+#     "Access": 100, 
+#     "Tagged": 200, 
+#     "Tagged All": 300,
+# }
+
+# interface_type = {
+#     "1000BASE-T (1GE)": 1000,
+#     "10GBASE-T (10GE)": 1150,
+#     "Virtual": 0,
+#     "Link Aggregation Group (LAG)": 200,
+# }
+
+# sites: 
+# for site in data["sites"]: 
+#     print(f"Creating or Updating Site {site['name']}")
+#     nb_data = nb.dcim.sites.get(slug=site["slug"])
+#     if not nb_data: 
+#         nb_data = nb.dcim.sites.create(name=site["name"], slug=site["slug"])
+
+# manufacturers 
+# for manufacturer in data["manufacturers"]: 
+#     print(f"Creating or Updating Manufacture {manufacturer['name']}")
+#     nb_data = nb.dcim.manufacturers.get(slug=manufacturer["slug"])
+#     if not nb_data: 
+#         nb_data = nb.dcim.manufacturers.create(name=manufacturer["name"], slug=manufacturer["slug"])
+
+# device_types
+# for device_type in data["device_types"]: 
+#     print(f"Creating or Updating device_type {device_type['model']}")
+#     nb_data = nb.dcim.device_types.get(slug=device_type["slug"])
+#     if not nb_data: 
+#         nb_data = nb.dcim.device_types.create(
+#             model=device_type["model"], 
+#             slug=device_type["slug"], 
+#             manufacturer=nb.dcim.manufacturers.get(slug=device_type["manufacturer_slug"]).id, 
+#             height=device_type["height"]
+#             )
+
+# device_roles
+# for device_role in data["device_roles"]: 
+#     print(f"Creating or Updating device_role {device_role['name']}")
+#     nb_data = nb.dcim.device_roles.get(slug=device_role["slug"])
+#     if not nb_data: 
+#         nb_data = nb.dcim.device_roles.create(
+#             name=device_role["name"], 
+#             slug=device_role["slug"], 
+#             color=device_role["color"]
+#             )
+
+# # platforms
+# for platform in data["platforms"]: 
+#     print(f"Creating or Updating platform {platform['name']}")
+#     nb_data = nb.dcim.platforms.get(slug=platform["slug"])
+#     if not nb_data: 
+#         nb_data = nb.dcim.platforms.create(
+#             name=platform["name"], 
+#             slug=platform["slug"], 
+#             manufacturer=nb.dcim.manufacturers.get(slug=platform["manufacturer_slug"]).id, 
+#             )
+
+# # vrfs 
+# for vrf in data["vrfs"]: 
+#     print(f"Creating or Updating vrf {vrf['name']}")
+#     nb_data = nb.ipam.vrfs.get(rd=vrf["rd"])
+#     if not nb_data: 
+#         nb_data = nb.ipam.vrfs.create(name=vrf["name"], rd=vrf["rd"])
+
+# # vlan-groups 
+# for group in data["vlan_groups"]: 
+#     print(f"Creating or updating vlan-group {group['name']}")
+#     nb_group = nb.ipam.vlan_groups.get(slug=group["slug"])
+#     if not nb_group: 
+#         nb_group = nb.ipam.vlan_groups.create(
+#             name = group["name"], 
+#             slug = group["slug"], 
+#             site=nb.dcim.sites.get(slug=group["site_slug"]).id,
+#         )
+#     # vlans
+#     for vlan in group["vlans"]: 
+#         print(f"Creating or updating vlan {vlan['name']}")
+#         nb_vlan = nb.ipam.vlans.get(
+#             group_id=nb_group.id, 
+#             vid=vlan["vid"],
+#             )
+#         if not nb_vlan: 
+#             nb_vlan = nb.ipam.vlans.create(
+#                 group=nb_group.id, 
+#                 site=nb_group.site.id, 
+#                 name=vlan["name"], 
+#                 vid=vlan["vid"], 
+#                 description=vlan["description"], 
+#             )
+#         if "prefix" in vlan.keys(): 
+#             print(f"Configuring prefix {vlan['prefix']}")
+#             nb_prefix = nb.ipam.prefixes.get(
+#                 vrf_id = nb.ipam.vrfs.get(rd=vlan["vrf"]).id, 
+#                 site_id=nb_group.site.id, 
+#                 vlan_vid=nb_vlan.vid, 
+#             )
+#             if not nb_prefix: 
+#                 # print("  Creating new prefix")
+#                 nb_prefix = nb.ipam.prefixes.create(
+#                     prefix=vlan["prefix"], 
+#                     vrf=nb.ipam.vrfs.get(rd=vlan["vrf"]).id,
+#                     description=vlan["description"],
+#                     site=nb_group.site.id, 
+#                     vlan=nb_vlan.id
+#                 )
+
+        

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -220,7 +220,7 @@ def verify_interface_vlans(netbox_interfaces, pyats_interfaces, pyats_vlans):
                     results["FAIL"].add(interface)
         else: 
             print(f"❌ {interface.name} MISSING from switch")
-            results["FAIL"].append(interface)
+            results["FAIL"].add(interface)
 
     # Convert results to lists from sets
     results = {


### PR DESCRIPTION
Not entirely sure about the logic behind using `append` only for this specific test but it fails as its not valid for `set()`.

Error traceback:
```
Traceback (most recent call last):
  File "check_device.py", line 48, in <module>
    interface_vlan_test = tests.verify_interface_vlans(netbox_interfaces, pyats_interfaces, pyats_vlans)
  File "/root/nxos-netbox-sync/utils/tests.py", line 223, in verify_interface_vlans
    results["FAIL"].append[interface]
AttributeError: 'set' object has no attribute 'append'
```

using `add` function instead works.